### PR TITLE
@storybook-addons/docs: Cannot read property 'replace' of null

### DIFF
--- a/packages/docs/src/components/code-highlighter.tsx
+++ b/packages/docs/src/components/code-highlighter.tsx
@@ -71,7 +71,7 @@ const Pre = styled.pre`
 `
 
 // TODO: Add line highlight.
-export const CodeHighlighter: FC<CodeHighlighterType> = ({ value, language }) => {
+export const CodeHighlighter: FC<CodeHighlighterType> = ({ value, language = '' }) => {
   const onCopyClick = useCallback(() => {
     copy(value)
   }, [value])


### PR DESCRIPTION
resolve #124